### PR TITLE
Add wildcard support

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,6 @@ This plugin does not support:
 
 Example configuration for the `mavenDependencies` parameter:
 ```
-regex:org\\.eclipse\\.microprofile:.*
+regex:org\.eclipse\.microprofile:.*
 com.github.javafaker:javafaker
 ```

--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ Two rules are made available in the `JavaScript` language by this plugin:
 Both of these take a configuration element for a newline seperated list of dependencies which are allowed in a given scope (`devDependencies` and `dependencies` respectively). When a rule in enabled for a scope, a rule violation will be raised for any dependencies which are not in the allowed list.
 
 This plugin does not support:
-* wildcards in dependency names
 * version numbers
 * identifying the line of the `package.json` file that the violation occured at
 
@@ -59,6 +58,8 @@ Example configuration value for the `npmDependencies` parameter value:
 @typescript-eslint/parser
 ```
 
+The default behaviour is to treat each row as an exact string match. Rows can be prefixed with `regex:` to interpret them as a regular expression. For example, `regex:@angular-eslint/.*` will allow all dependencies in the `@angular-eslint` scope.
+
 ### Maven Rules
 
 Three rules are made available in the `Java` language by this plugin. Two of these are regular rules:
@@ -69,15 +70,14 @@ Three rules are made available in the `Java` language by this plugin. Two of the
 * Allowed Dependencies (template) - `allowed-dependencies-maven:maven-allowed-dependencies`
     * A template rule which allows custom rules to be created targeting a set list of scopes. This has an extra `mavenScopes` parameter for supplying a comma seperated list of scopes.
 
-Both of these take a configuration element for a newline seperated list of dependencies, as `groupId:artifactId` entries, which are allowed in the scopes associated with the rule. When a rule in enabled for a scope, a rule violation will be raised for any dependencies which are not in the allowed list.
+Both of these take a configuration element for a newline seperated list of dependencies, as `groupId:artifactId` entries, which are allowed in the scopes associated with the rule. The default behaviour is to treat each row as an exact string match. Rows can be prefixed with `regex:` to interpret them as a regular expression. For example, `regex:org.\\junit\\.jupiter:.*` will allow all dependencies with the `groupId` of `org.junit.jupiter`. When a rule in enabled for a scope, a rule violation will be raised for any dependencies which are not in the allowed list.
 
 This plugin does not support:
-* wildcards in dependency names
 * version numbers
 
 
 Example configuration for the `mavenDependencies` parameter:
 ```
-org.eclipse.microprofile:microprofile
+regex:org\\.eclipse\\.microprofile:.*
 com.github.javafaker:javafaker
 ```

--- a/src/main/java/com/devwithimagination/sonar/alloweddependencies/plugin/maven/checks/AllowedMavenDependenciesCheck.java
+++ b/src/main/java/com/devwithimagination/sonar/alloweddependencies/plugin/maven/checks/AllowedMavenDependenciesCheck.java
@@ -69,7 +69,9 @@ public class AllowedMavenDependenciesCheck extends SimpleXPathBasedCheck {
                 final String listKey = groupId + ":" + artifactId;
 
                 if ((config.getScopes().isEmpty() || config.getScopes().contains(scope))
-                        && !config.getAllowedDependencies().contains(listKey)) {
+                        && !config.getAllowedDependenciesPredicate().test(listKey)) {
+
+                    LOG.info("Forbidden dependency: {}", listKey);
 
                     reportIssue(dependency, "Remove this forbidden dependency.");
                 }

--- a/src/main/java/com/devwithimagination/sonar/alloweddependencies/plugin/util/PredicateFactory.java
+++ b/src/main/java/com/devwithimagination/sonar/alloweddependencies/plugin/util/PredicateFactory.java
@@ -1,0 +1,76 @@
+package com.devwithimagination.sonar.alloweddependencies.plugin.util;
+
+import java.util.Arrays;
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
+
+import org.sonar.api.utils.log.Logger;
+import org.sonar.api.utils.log.Loggers;
+
+/**
+ * Class for creating Predicates for matching dependencies against.
+ */
+public class PredicateFactory {
+
+    private static final String REGEX_PREFIX = "regex:";
+
+    private static final String COMMENT_LINE_PREFIX = "#";
+
+    /**
+     * Logger
+     */
+    private static final Logger LOG = Loggers.get(PredicateFactory.class);
+
+    /**
+     * Create a predicate that will match any of the dependencies.
+     *
+     * @param deps the newline seperated list of dependency items which are valid.
+     *             If a row is prefixed with {@value #REGEX_PREFIX} then it will be
+     *             interpreted as a regular expression. Any line starting with '#'
+     *             will be ignored.
+     * @return the created {@link Predicate}.
+     */
+    public Predicate<String> createPredicateForDependencyListString(final String deps) {
+
+        LOG.info("Allowed dependencies: '{}'", deps);
+
+        if (deps == null) {
+            return (t -> false);
+        } else {
+
+            return Arrays.asList(deps.split("\\r?\\n"))
+                    .stream()
+                    .map(String::trim)
+                    .filter(v -> !v.startsWith(COMMENT_LINE_PREFIX))
+                    .sorted()
+                    .map(this::createPredicateForSingleDependencyRow)
+                    .reduce(x -> false, Predicate::or);
+        }
+    }
+
+    /**
+     * Create a predicate for a single dependency item.
+     *
+     * @param deps the newline seperated list of dependency items which are valid.
+     *             If a row is prefixed with {@value #REGEX_PREFIX} then it will be
+     *             interpreted as a regular expression.
+     * @return the created {@link Predicate}.
+     */
+    Predicate<String> createPredicateForSingleDependencyRow(final String dep) {
+
+        if (dep.startsWith(REGEX_PREFIX)) {
+            /*
+             * Create a predicate for a regex expression, we always enable the case
+             * insensitive flags
+             */
+            final String pattern = dep.substring(REGEX_PREFIX.length());
+
+            return Pattern.compile(pattern, Pattern.CASE_INSENSITIVE).asPredicate();
+        } else {
+            /* Exact string match */
+            return dep::equalsIgnoreCase;
+        }
+
+    }
+
+}

--- a/src/test/java/com/devwithimagination/sonar/alloweddependencies/plugin/maven/check/TestAllowedMavenDependenciesCheck.java
+++ b/src/test/java/com/devwithimagination/sonar/alloweddependencies/plugin/maven/check/TestAllowedMavenDependenciesCheck.java
@@ -122,22 +122,21 @@ class TestAllowedMavenDependenciesCheck {
             Arguments.of(
                 createTemplatedTestRule(RuleKey.of(MavenRulesDefinition.REPOSITORY_MAVEN, "my-compile-deps"),
                     "com.github.javafaker:javafaker",
-                    "compile"),
+                    "compile")),
             Arguments.of(
                 createNonTemplatedTestRule(
                     MavenRulesDefinition.RULE_MAVEN_ALLOWED_TEST,
                     String.join("\n",
                         "junit:junit",
+                        "regex:org\\.junit\\.jupiter:.*",
                         "com.nimbusds:nimbus-jose-jwt",
                         "org.glassfish.jersey.core:jersey-client",
                         "org.bouncycastle:bcpkix-jdk15on",
-                        "org.apache.logging.log4j:log4j-slf4j18-impl",
-                        "org.apache.cxf:cxf-rt-rs-mp-client",
+                        "regex:org\\.apache\\..*:.*",
                         "org.eclipse.microprofile.rest.client:microprofile-rest-client-api",
                         "com.opentable.components:otj-pg-embedded",
                         "org.flywaydb:flyway-core",
                         "org.jacoco:org.jacoco.agent")))
-            )
         );
 
     }
@@ -148,7 +147,6 @@ class TestAllowedMavenDependenciesCheck {
      */
     private static Stream<Arguments> provideViolationParameters() {
 
-        //TODO: Change one of these to use the main rule key setup
         return Stream.of(
             Arguments.of(
                 createTemplatedTestRule(RuleKey.of(MavenRulesDefinition.REPOSITORY_MAVEN, "no-compile-deps"),
@@ -178,6 +176,18 @@ class TestAllowedMavenDependenciesCheck {
                 createTemplatedTestRule(RuleKey.of(MavenRulesDefinition.REPOSITORY_MAVEN, "some-test-deps"),
                     String.join("\n",
                         "junit:junit",
+                        // Not the right groupId, shouldn't match
+                        "regex:org\\.junit:.*",
+                        "com.nimbusds:nimbus-jose-jwt",
+                        "org.glassfish.jersey.core:jersey-client"),
+                    "test"),
+                10
+            ),
+            Arguments.of(
+                createTemplatedTestRule(RuleKey.of(MavenRulesDefinition.REPOSITORY_MAVEN, "some-test-deps"),
+                    String.join("\n",
+                        "junit:junit",
+                        "regex:org\\.junit\\.jupiter:.*",
                         "com.nimbusds:nimbus-jose-jwt",
                         "org.glassfish.jersey.core:jersey-client"),
                     "test"),
@@ -189,7 +199,7 @@ class TestAllowedMavenDependenciesCheck {
                         "junit:junit",
                         "com.nimbusds:nimbus-jose-jwt",
                         "org.glassfish.jersey.core:jersey-client")),
-                7
+                10
             )
         );
 

--- a/src/test/java/com/devwithimagination/sonar/alloweddependencies/plugin/maven/check/TestAllowedMavenDependenciesCheckConfig.java
+++ b/src/test/java/com/devwithimagination/sonar/alloweddependencies/plugin/maven/check/TestAllowedMavenDependenciesCheckConfig.java
@@ -1,6 +1,7 @@
 package com.devwithimagination.sonar.alloweddependencies.plugin.maven.check;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Arrays;
@@ -33,8 +34,7 @@ class TestAllowedMavenDependenciesCheckConfig {
         /* Create the config */
         final AllowedMavenDependenciesCheckConfig config = new AllowedMavenDependenciesCheckConfig(rule);
 
-        assertEquals(2, config.getAllowedDependencies().size(), "Expected 2 dependencies in the list");
-        assertEquals(Arrays.asList("abc:def", "org.junit:junit"), config.getAllowedDependencies(), "Expected dependencies to match");
+        assertNotNull(config.getAllowedDependenciesPredicate(), "Expected predicate to be created");
 
         assertEquals(3, config.getScopes().size(), "Expected 3 scopes");
         assertEquals(Arrays.asList("compile", "provided", "runtime"), config.getScopes(), "Expected scopes to match");
@@ -55,8 +55,7 @@ class TestAllowedMavenDependenciesCheckConfig {
         final AllowedMavenDependenciesCheckConfig config = new AllowedMavenDependenciesCheckConfig(rule);
 
         /* Perform assertions */
-        assertEquals(2, config.getAllowedDependencies().size(), "Expected 2 dependencies in the list");
-        assertEquals(Arrays.asList("abc:def", "group:artifact"), config.getAllowedDependencies(), "Expected dependencies to match");
+        assertNotNull(config.getAllowedDependenciesPredicate(), "Expected predicate to be created");
 
         assertEquals(1, config.getScopes().size(), "Expected 1 scope");
         assertEquals("test", config.getScopes().get(0));

--- a/src/test/java/com/devwithimagination/sonar/alloweddependencies/plugin/maven/sensors/TestCreateIssuesOnMavenDependenciesSensor.java
+++ b/src/test/java/com/devwithimagination/sonar/alloweddependencies/plugin/maven/sensors/TestCreateIssuesOnMavenDependenciesSensor.java
@@ -80,7 +80,7 @@ class TestCreateIssuesOnMavenDependenciesSensor {
         sensor.execute(sensorContext);
 
         /* Verify things happened */
-        assertEquals(13, sensorContext.allIssues().size(), "Expecting violations for all dependencies");
+        assertEquals(17, sensorContext.allIssues().size(), "Expecting violations for all dependencies");
 
     }
 

--- a/src/test/java/com/devwithimagination/sonar/alloweddependencies/plugin/npm/check/TestAllowedNpmDependenciesCheck.java
+++ b/src/test/java/com/devwithimagination/sonar/alloweddependencies/plugin/npm/check/TestAllowedNpmDependenciesCheck.java
@@ -155,6 +155,11 @@ class TestAllowedNpmDependenciesCheck {
                     "@angular/language-service",
                     "@cypress/code-coverage")),
             Arguments.of(
+                NpmRulesDefinition.RULE_NPM_ALLOWED_DEV,
+                String.join("\n",
+                    "regex:@angular/.*",
+                    "@cypress/code-coverage")),
+            Arguments.of(
                 NpmRulesDefinition.RULE_NPM_ALLOWED,
                 String.join("\n",
                     "primeicons",
@@ -177,6 +182,10 @@ class TestAllowedNpmDependenciesCheck {
                 NpmRulesDefinition.RULE_NPM_ALLOWED_DEV,
                 "@cypress/code-coverage",
                 3 ),
+            Arguments.of(
+                NpmRulesDefinition.RULE_NPM_ALLOWED_DEV,
+                "regex:@angular/.*",
+                1),
             Arguments.of(
                 NpmRulesDefinition.RULE_NPM_ALLOWED_DEV,
                 null,

--- a/src/test/java/com/devwithimagination/sonar/alloweddependencies/plugin/util/TestPredicateFactory.java
+++ b/src/test/java/com/devwithimagination/sonar/alloweddependencies/plugin/util/TestPredicateFactory.java
@@ -1,0 +1,93 @@
+package com.devwithimagination.sonar.alloweddependencies.plugin.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Test class for the PredicateFactory.
+ */
+class TestPredicateFactory {
+
+    /**
+     * Test if a predicate created by the {@link PredicateFactory} matches a
+     * supplied dependency item.
+     *
+     * @param allowedDeps   the newline seperated string of dependencies which are
+     *                      allowed.
+     * @param testDep       the dependency item to compare with the predicate
+     * @param expectedMatch the expected result - if the created predicate should
+     *                      find a match or not.
+     */
+    @ParameterizedTest
+    @MethodSource("provideTestArguments")
+    void testPredicates(final String allowedDeps, final String testDep, final boolean expectedMatch) {
+
+        final PredicateFactory factory = new PredicateFactory();
+
+        final Predicate<String> predicate = factory.createPredicateForDependencyListString(allowedDeps);
+
+        final boolean matches = predicate.test(testDep);
+        assertEquals(expectedMatch, matches);
+
+    }
+
+    private static Stream<Arguments> provideTestArguments() {
+        return Stream.of(
+            /* Regex tests */
+            Arguments.of(
+                "regex:org\\.junit\\.*",
+                "org.junit.dep:the-dep",
+                true
+            ),
+            Arguments.of(
+                "regex:org\\.junit\\.jupiter\\.*",
+                "org.junit.dep:the-dep",
+                false
+            ),
+            Arguments.of(
+                "regex:org\\.junit\\.*\n" +
+                "a-dep",
+                "org.junit.dep:the-dep",
+                true
+            ),
+            /* String tests */
+            Arguments.of(
+                "a-dep",
+                "a-dep",
+                true
+            ),
+            Arguments.of(
+                "a-dep",
+                "b-dep",
+                false
+            ),
+            Arguments.of(
+                "regex:org\\.junit\\.*\n" +
+                "a-dep",
+                "a-dep",
+                true
+            ),
+
+            /* Testing comments */
+            Arguments.of(
+                "#a-dep\n" +
+                "a-dep",
+                "#a-dep",
+                false
+            ),
+            Arguments.of(
+                "#a-dep\n" +
+                "a-dep",
+                "a-dep",
+                true
+            )
+        );
+    }
+
+}

--- a/src/test/resources/maven/pom.xml
+++ b/src/test/resources/maven/pom.xml
@@ -1,126 +1,155 @@
-<?xml version="1.0" encoding="UTF-8" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <modelVersion>4.0.0</modelVersion>
-  <groupId>com.devwithimagination.microprofile</groupId>
-  <artifactId>experiments</artifactId>
-  <version>0.3-SNAPSHOT</version>
-  <packaging>war</packaging>
-  <properties>
-    <failOnMissingWebXml>false</failOnMissingWebXml>
-    <maven.compiler.source>11</maven.compiler.source>
-    <maven.compiler.target>11</maven.compiler.target>
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.devwithimagination.microprofile</groupId>
+    <artifactId>experiments</artifactId>
+    <version>0.3-SNAPSHOT</version>
+    <packaging>war</packaging>
+    <properties>
+        <failOnMissingWebXml>false</failOnMissingWebXml>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
 
-    <maven.dependency.plugin.version>3.1.1</maven.dependency.plugin.version>
-    <maven.surefire.version>2.22.2</maven.surefire.version>
-    <maven.failsafe.version>2.22.2</maven.failsafe.version>
-    <arquillian.version>1.1.14.Final</arquillian.version>
-    <cxf.client.version>3.3.3</cxf.client.version>
-    <mp.rest.client.version>1.3.3</mp.rest.client.version>
-    <payara.version>5.193</payara.version>
-    <payaramicro.maven.plugin.version>1.0.6</payaramicro.maven.plugin.version>
-    <pg.embedded.version>0.13.1</pg.embedded.version>
-    <flyway.version>5.2.4</flyway.version>
-    <log.version>2.12.1</log.version>
-    <jacoco.plugin.version>0.8.4</jacoco.plugin.version>
+        <maven.dependency.plugin.version>3.1.1</maven.dependency.plugin.version>
+        <maven.surefire.version>2.22.2</maven.surefire.version>
+        <maven.failsafe.version>2.22.2</maven.failsafe.version>
+        <arquillian.version>1.1.14.Final</arquillian.version>
+        <cxf.client.version>3.3.3</cxf.client.version>
+        <mp.rest.client.version>1.3.3</mp.rest.client.version>
+        <payara.version>5.193</payara.version>
+        <payaramicro.maven.plugin.version>1.0.6</payaramicro.maven.plugin.version>
+        <pg.embedded.version>0.13.1</pg.embedded.version>
+        <flyway.version>5.2.4</flyway.version>
+        <log.version>2.12.1</log.version>
+        <jacoco.plugin.version>0.8.4</jacoco.plugin.version>
 
-    <!-- Properties for dependencies -->
-    <!-- Must be listed in the dependencies section otherwise it will be null. -->
-    <jacoco.agent.path>${org.jacoco:org.jacoco.agent:jar:runtime}</jacoco.agent.path>
+        <!-- Properties for dependencies -->
+        <!-- Must be listed in the dependencies section otherwise it will be null. -->
+        <jacoco.agent.path>${org.jacoco:org.jacoco.agent:jar:runtime}</jacoco.agent.path>
 
-  </properties>
-  <dependencies>
-    <dependency>
-      <groupId>org.eclipse.microprofile</groupId>
-      <artifactId>microprofile</artifactId>
-      <version>2.1</version>
-      <type>pom</type>
-      <scope>provided</scope>
-    </dependency>
-    <!-- Additional JCache API -->
-    <dependency>
-      <groupId>javax.cache</groupId>
-      <artifactId>cache-api</artifactId>
-      <version>1.0.0</version>
-      <scope>provided</scope>
-    </dependency>
+    </properties>
 
-    <!-- For generating fake test data -->
-    <dependency>
-      <groupId>com.github.javafaker</groupId>
-      <artifactId>javafaker</artifactId>
-      <version>0.12</version>
-    </dependency>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>5.7.1</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.eclipse.microprofile</groupId>
+            <artifactId>microprofile</artifactId>
+            <version>2.1</version>
+            <type>pom</type>
+            <scope>provided</scope>
+        </dependency>
+        <!-- Additional JCache API -->
+        <dependency>
+            <groupId>javax.cache</groupId>
+            <artifactId>cache-api</artifactId>
+            <version>1.0.0</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- For generating fake test data -->
+        <dependency>
+            <groupId>com.github.javafaker</groupId>
+            <artifactId>javafaker</artifactId>
+            <version>0.12</version>
+        </dependency>
 
 
-    <!-- Testing -->
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.12</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.nimbusds</groupId>
-      <artifactId>nimbus-jose-jwt</artifactId>
-      <version>7.9</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.glassfish.jersey.core</groupId>
-      <artifactId>jersey-client</artifactId>
-      <version>2.25.1</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.bouncycastle</groupId>
-      <artifactId>bcpkix-jdk15on</artifactId>
-      <version>1.53</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j18-impl</artifactId>
-      <version>${log.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <!-- Test rest client implementations-->
-    <dependency>
-      <groupId>org.apache.cxf</groupId>
-      <artifactId>cxf-rt-rs-mp-client</artifactId>
-      <version>${cxf.client.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.microprofile.rest.client</groupId>
-      <artifactId>microprofile-rest-client-api</artifactId>
-      <version>${mp.rest.client.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <!--Test database components-->
-    <dependency>
-      <groupId>com.opentable.components</groupId>
-      <artifactId>otj-pg-embedded</artifactId>
-      <version>${pg.embedded.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.flywaydb</groupId>
-      <artifactId>flyway-core</artifactId>
-      <version>${flyway.version}</version>
-      <scope>test</scope>
-    </dependency>
+        <!-- Testing -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
 
-    <!-- Coverage agent -->
-    <dependency>
-        <groupId>org.jacoco</groupId>
-        <artifactId>org.jacoco.agent</artifactId>
-        <version>${jacoco.plugin.version}</version>
-        <classifier>runtime</classifier>
-        <scope>test</scope>
-    </dependency>
-  </dependencies>
-  <build>
-    <finalName>${project.artifactId}</finalName>
-  </build>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.nimbusds</groupId>
+            <artifactId>nimbus-jose-jwt</artifactId>
+            <version>7.9</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.core</groupId>
+            <artifactId>jersey-client</artifactId>
+            <version>2.25.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcpkix-jdk15on</artifactId>
+            <version>1.53</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j18-impl</artifactId>
+            <version>${log.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <!-- Test rest client implementations-->
+        <dependency>
+            <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-rt-rs-mp-client</artifactId>
+            <version>${cxf.client.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.microprofile.rest.client</groupId>
+            <artifactId>microprofile-rest-client-api</artifactId>
+            <version>${mp.rest.client.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <!--Test database components-->
+        <dependency>
+            <groupId>com.opentable.components</groupId>
+            <artifactId>otj-pg-embedded</artifactId>
+            <version>${pg.embedded.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-core</artifactId>
+            <version>${flyway.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Coverage agent -->
+        <dependency>
+            <groupId>org.jacoco</groupId>
+            <artifactId>org.jacoco.agent</artifactId>
+            <version>${jacoco.plugin.version}</version>
+            <classifier>runtime</classifier>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+    <build>
+        <finalName>${project.artifactId}</finalName>
+    </build>
 
 </project>


### PR DESCRIPTION
Adds the ability to prefix configuration rows with `regex:` to have them interpreted as regular expressions. 