### PR TITLE
feat: added support for flattened pom files

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This [SonarQube](http://www.sonarqube.org/) plugin ensures that projects in an o
 
 This plugin exposes rules for the following dependency descriptor files:
 * NPM `package.json`
-* Maven `pom.xml`
+* Maven `pom.xml` / `.flattened-pom.xml`
 
 This plugin does not:
 * Check dependency licencies, [sonarqube-licensecheck](https://github.com/porscheinformatik/sonarqube-licensecheck) does that
@@ -24,7 +24,7 @@ Download the latest (non-snapshot) version of the [package](https://github.com/d
 
 ## Usage
 
-This plugin requires that the files to be scanned (e.g. `pom.xml` or `package.json`) is included in the sources path which SonarQube is configured to analyse.
+This plugin requires that the files to be scanned (e.g. `pom.xml`, `.flattened-pom.xml` or `package.json`) is included in the sources path which SonarQube is configured to analyse.
 
 Example in sonar-project.properties
 ```
@@ -71,6 +71,8 @@ Three rules are made available in the `Java` language by this plugin. Two of the
     * A template rule which allows custom rules to be created targeting a set list of scopes. This has an extra `mavenScopes` parameter for supplying a comma seperated list of scopes.
 
 Both of these take a configuration element for a newline seperated list of dependencies, as `groupId:artifactId` entries, which are allowed in the scopes associated with the rule. The default behaviour is to treat each row as an exact string match. Rows can be prefixed with `regex:` to interpret them as a regular expression. For example, `regex:org.\\junit\\.jupiter:.*` will allow all dependencies with the `groupId` of `org.junit.jupiter`. When a rule in enabled for a scope, a rule violation will be raised for any dependencies which are not in the allowed list.
+
+Where a project uses the [maven-flatten-plugin](https://www.mojohaus.org/flatten-maven-plugin/index.html), this plugin will scan the created `.flattened-pom.xml` file. Note that depending on the `flattenMode` value used this may lose valuable information. This has primarily been tested with `resolveCiFriendliesOnly` which only flattens version number properties.
 
 This plugin does not support:
 * version numbers

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.devwithimagination</groupId>
     <artifactId>sonar-alloweddependencies-plugin</artifactId>
-    <version>0.0.16-SNAPSHOT</version>
+    <version>0.1.6-SNAPSHOT</version>
 
     <licenses>
         <license>

--- a/src/main/java/com/devwithimagination/sonar/alloweddependencies/plugin/maven/checks/AllowedMavenDependenciesCheck.java
+++ b/src/main/java/com/devwithimagination/sonar/alloweddependencies/plugin/maven/checks/AllowedMavenDependenciesCheck.java
@@ -1,5 +1,8 @@
 package com.devwithimagination.sonar.alloweddependencies.plugin.maven.checks;
 
+import java.util.Arrays;
+import java.util.List;
+
 import javax.annotation.Nonnull;
 import javax.xml.xpath.XPathExpression;
 
@@ -28,6 +31,11 @@ public class AllowedMavenDependenciesCheck extends SimpleXPathBasedCheck {
      */
     private static final Logger LOG = Loggers.get(AllowedMavenDependenciesCheck.class);
 
+    private static final List<String> ALLOWED_FILE_NAMES = Arrays.asList(
+        "pom.xml",
+        ".flattened-pom.xml"
+    );
+
     /**
      * The XPath Expression used to find maven dependency nodes in a pom file.
      */
@@ -51,10 +59,10 @@ public class AllowedMavenDependenciesCheck extends SimpleXPathBasedCheck {
     }
 
     @Override
-    public void scanFile(XmlFile xmlFile) {
+    public void scanFile(final XmlFile xmlFile) {
 
         /* Only scan pom.xml files */
-        if ("pom.xml".equalsIgnoreCase(xmlFile.getInputFile().filename())) {
+        if (ALLOWED_FILE_NAMES.contains(xmlFile.getInputFile().filename().toLowerCase())) {
 
             /*
              * Iterate through matches for the XPath expression and compare with the list of

--- a/src/test/java/com/devwithimagination/sonar/alloweddependencies/plugin/maven/check/TestAllowedMavenDependenciesCheck.java
+++ b/src/test/java/com/devwithimagination/sonar/alloweddependencies/plugin/maven/check/TestAllowedMavenDependenciesCheck.java
@@ -75,13 +75,14 @@ class TestAllowedMavenDependenciesCheck {
      * Creates tests for the dev and regular dependencies with all the appropriate test file
      * dependencies configured, to ensure we get no issues raised.
      *
+     * @param fileName the name of the file to scan
      * @param rule the rule being tested.
      */
     @ParameterizedTest
     @MethodSource("provideNoViolationParameters")
-    void checkForNoViolations(final ActiveRule rule) throws IOException {
+    void checkForNoViolations(final String fileName, final ActiveRule rule) throws IOException {
 
-        setup("pom.xml");
+        setup(fileName);
 
         /* Scan our test file, and confirm no issues were raised */
         final AllowedMavenDependenciesCheckConfig config = new AllowedMavenDependenciesCheckConfig(rule);
@@ -122,10 +123,12 @@ class TestAllowedMavenDependenciesCheck {
 
         return Stream.of(
             Arguments.of(
+                "pom.xml",
                 createTemplatedTestRule(RuleKey.of(MavenRulesDefinition.REPOSITORY_MAVEN, "my-compile-deps"),
                     "com.github.javafaker:javafaker",
                     "compile")),
             Arguments.of(
+                "pom.xml",
                 createNonTemplatedTestRule(
                     MavenRulesDefinition.RULE_MAVEN_ALLOWED_TEST,
                     String.join("\n",
@@ -138,7 +141,18 @@ class TestAllowedMavenDependenciesCheck {
                         "org.eclipse.microprofile.rest.client:microprofile-rest-client-api",
                         "com.opentable.components:otj-pg-embedded",
                         "org.flywaydb:flyway-core",
-                        "org.jacoco:org.jacoco.agent")))
+                        "org.jacoco:org.jacoco.agent"))),
+            Arguments.of(
+                /* If this scanned against the regular pom.xml file it would fail,
+                 * but for this test we include a file which will not pass the name
+                 * check so should be ignored.
+                 */
+                "not-pom.xml",
+                createNonTemplatedTestRule(
+                    MavenRulesDefinition.RULE_MAVEN_ALLOWED_TEST,
+                    String.join("\n",
+                        "junit:junit",
+                        "regex:org\\.junit\\.jupiter:.*")))
         );
 
     }

--- a/src/test/java/com/devwithimagination/sonar/alloweddependencies/plugin/maven/check/TestAllowedMavenDependenciesCheck.java
+++ b/src/test/java/com/devwithimagination/sonar/alloweddependencies/plugin/maven/check/TestAllowedMavenDependenciesCheck.java
@@ -17,7 +17,6 @@ import com.devwithimagination.sonar.alloweddependencies.plugin.maven.checks.Allo
 import com.devwithimagination.sonar.alloweddependencies.plugin.maven.checks.AllowedMavenDependenciesCheckConfig;
 import com.devwithimagination.sonar.alloweddependencies.plugin.maven.rules.MavenRulesDefinition;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -48,12 +47,11 @@ class TestAllowedMavenDependenciesCheck {
      * Setup any configuration between tests.
      * @throws IOException
      */
-    @BeforeEach
-    void setup() throws IOException {
+    private void setup(final String filename) throws IOException {
 
         /* Setup the test project location */
         final File moduleBaseDir = new File("src/test/resources/maven");
-        final File testFile = new File(moduleBaseDir, "pom.xml");
+        final File testFile = new File(moduleBaseDir, filename);
         final String fileContents = String.join(System.lineSeparator(), Files.readAllLines(testFile.toPath()));
 
         final InputFile testInputFile = TestInputFileBuilder.create(
@@ -81,7 +79,9 @@ class TestAllowedMavenDependenciesCheck {
      */
     @ParameterizedTest
     @MethodSource("provideNoViolationParameters")
-    void checkForNoViolations(final ActiveRule rule) {
+    void checkForNoViolations(final ActiveRule rule) throws IOException {
+
+        setup("pom.xml");
 
         /* Scan our test file, and confirm no issues were raised */
         final AllowedMavenDependenciesCheckConfig config = new AllowedMavenDependenciesCheckConfig(rule);
@@ -101,7 +101,9 @@ class TestAllowedMavenDependenciesCheck {
      */
     @ParameterizedTest
     @MethodSource("provideViolationParameters")
-    void checkForViolations(final ActiveRule rule, final int expectedIssues) {
+    void checkForViolations(final String filename, final ActiveRule rule, final int expectedIssues) throws IOException {
+
+        setup(filename);
 
         /* Scan our test file, and confirm the right number of issues were raised */
         final AllowedMavenDependenciesCheckConfig config = new AllowedMavenDependenciesCheckConfig(rule);
@@ -149,30 +151,42 @@ class TestAllowedMavenDependenciesCheck {
 
         return Stream.of(
             Arguments.of(
+                "pom.xml",
                 createTemplatedTestRule(RuleKey.of(MavenRulesDefinition.REPOSITORY_MAVEN, "no-compile-deps"),
                     "",
                     "compile"),
                 1),
             Arguments.of(
+                "pom.xml",
                 createTemplatedTestRule(RuleKey.of(MavenRulesDefinition.REPOSITORY_MAVEN, "no-provided-deps"),
                     "",
                     "provided"),
                 2),
             Arguments.of(
+                "pom.xml",
                 createTemplatedTestRule(RuleKey.of(MavenRulesDefinition.REPOSITORY_MAVEN, "no-combined-compile-provided-deps"),
                     "",
                     "compile,provided"),
                 3),
             Arguments.of(
+                "pom.xml",
                 createNonTemplatedTestRule(MavenRulesDefinition.RULE_MAVEN_ALLOWED_MAIN,
                     "javax.cache:cache-api"),
                 2),
             Arguments.of(
+                "pom.xml",
                 createTemplatedTestRule(RuleKey.of(MavenRulesDefinition.REPOSITORY_MAVEN, "one-provided-deps"),
                     "javax.cache:cache-api",
                     "provided"),
                 1),
             Arguments.of(
+                ".flattened-pom.xml",
+                createTemplatedTestRule(RuleKey.of(MavenRulesDefinition.REPOSITORY_MAVEN, "one-provided-deps"),
+                    "javax.cache:cache-api",
+                    "provided"),
+                1),
+            Arguments.of(
+                "pom.xml",
                 createTemplatedTestRule(RuleKey.of(MavenRulesDefinition.REPOSITORY_MAVEN, "some-test-deps"),
                     String.join("\n",
                         "junit:junit",
@@ -184,6 +198,7 @@ class TestAllowedMavenDependenciesCheck {
                 10
             ),
             Arguments.of(
+                "pom.xml",
                 createTemplatedTestRule(RuleKey.of(MavenRulesDefinition.REPOSITORY_MAVEN, "some-test-deps"),
                     String.join("\n",
                         "junit:junit",
@@ -194,6 +209,7 @@ class TestAllowedMavenDependenciesCheck {
                 7
             ),
             Arguments.of(
+                "pom.xml",
                 createNonTemplatedTestRule(MavenRulesDefinition.RULE_MAVEN_ALLOWED_TEST,
                     String.join("\n",
                         "junit:junit",

--- a/src/test/resources/maven/.flattened-pom.xml
+++ b/src/test/resources/maven/.flattened-pom.xml
@@ -1,0 +1,155 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.devwithimagination.microprofile</groupId>
+    <artifactId>experiments</artifactId>
+    <version>0.3-SNAPSHOT</version>
+    <packaging>war</packaging>
+    <properties>
+        <failOnMissingWebXml>false</failOnMissingWebXml>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+
+        <maven.dependency.plugin.version>3.1.1</maven.dependency.plugin.version>
+        <maven.surefire.version>2.22.2</maven.surefire.version>
+        <maven.failsafe.version>2.22.2</maven.failsafe.version>
+        <arquillian.version>1.1.14.Final</arquillian.version>
+        <cxf.client.version>3.3.3</cxf.client.version>
+        <mp.rest.client.version>1.3.3</mp.rest.client.version>
+        <payara.version>5.193</payara.version>
+        <payaramicro.maven.plugin.version>1.0.6</payaramicro.maven.plugin.version>
+        <pg.embedded.version>0.13.1</pg.embedded.version>
+        <flyway.version>5.2.4</flyway.version>
+        <log.version>2.12.1</log.version>
+        <jacoco.plugin.version>0.8.4</jacoco.plugin.version>
+
+        <!-- Properties for dependencies -->
+        <!-- Must be listed in the dependencies section otherwise it will be null. -->
+        <jacoco.agent.path>${org.jacoco:org.jacoco.agent:jar:runtime}</jacoco.agent.path>
+
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>5.7.1</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.eclipse.microprofile</groupId>
+            <artifactId>microprofile</artifactId>
+            <version>2.1</version>
+            <type>pom</type>
+            <scope>provided</scope>
+        </dependency>
+        <!-- Additional JCache API -->
+        <dependency>
+            <groupId>javax.cache</groupId>
+            <artifactId>cache-api</artifactId>
+            <version>1.0.0</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- For generating fake test data -->
+        <dependency>
+            <groupId>com.github.javafaker</groupId>
+            <artifactId>javafaker</artifactId>
+            <version>0.12</version>
+        </dependency>
+
+
+        <!-- Testing -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.nimbusds</groupId>
+            <artifactId>nimbus-jose-jwt</artifactId>
+            <version>7.9</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.core</groupId>
+            <artifactId>jersey-client</artifactId>
+            <version>2.25.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcpkix-jdk15on</artifactId>
+            <version>1.53</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j18-impl</artifactId>
+            <version>${log.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <!-- Test rest client implementations-->
+        <dependency>
+            <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-rt-rs-mp-client</artifactId>
+            <version>${cxf.client.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.microprofile.rest.client</groupId>
+            <artifactId>microprofile-rest-client-api</artifactId>
+            <version>${mp.rest.client.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <!--Test database components-->
+        <dependency>
+            <groupId>com.opentable.components</groupId>
+            <artifactId>otj-pg-embedded</artifactId>
+            <version>${pg.embedded.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-core</artifactId>
+            <version>${flyway.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Coverage agent -->
+        <dependency>
+            <groupId>org.jacoco</groupId>
+            <artifactId>org.jacoco.agent</artifactId>
+            <version>${jacoco.plugin.version}</version>
+            <classifier>runtime</classifier>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+    <build>
+        <finalName>${project.artifactId}</finalName>
+    </build>
+
+</project>

--- a/src/test/resources/maven/not-pom.xml
+++ b/src/test/resources/maven/not-pom.xml
@@ -1,0 +1,155 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.devwithimagination.microprofile</groupId>
+    <artifactId>experiments</artifactId>
+    <version>0.3-SNAPSHOT</version>
+    <packaging>war</packaging>
+    <properties>
+        <failOnMissingWebXml>false</failOnMissingWebXml>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+
+        <maven.dependency.plugin.version>3.1.1</maven.dependency.plugin.version>
+        <maven.surefire.version>2.22.2</maven.surefire.version>
+        <maven.failsafe.version>2.22.2</maven.failsafe.version>
+        <arquillian.version>1.1.14.Final</arquillian.version>
+        <cxf.client.version>3.3.3</cxf.client.version>
+        <mp.rest.client.version>1.3.3</mp.rest.client.version>
+        <payara.version>5.193</payara.version>
+        <payaramicro.maven.plugin.version>1.0.6</payaramicro.maven.plugin.version>
+        <pg.embedded.version>0.13.1</pg.embedded.version>
+        <flyway.version>5.2.4</flyway.version>
+        <log.version>2.12.1</log.version>
+        <jacoco.plugin.version>0.8.4</jacoco.plugin.version>
+
+        <!-- Properties for dependencies -->
+        <!-- Must be listed in the dependencies section otherwise it will be null. -->
+        <jacoco.agent.path>${org.jacoco:org.jacoco.agent:jar:runtime}</jacoco.agent.path>
+
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>5.7.1</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.eclipse.microprofile</groupId>
+            <artifactId>microprofile</artifactId>
+            <version>2.1</version>
+            <type>pom</type>
+            <scope>provided</scope>
+        </dependency>
+        <!-- Additional JCache API -->
+        <dependency>
+            <groupId>javax.cache</groupId>
+            <artifactId>cache-api</artifactId>
+            <version>1.0.0</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- For generating fake test data -->
+        <dependency>
+            <groupId>com.github.javafaker</groupId>
+            <artifactId>javafaker</artifactId>
+            <version>0.12</version>
+        </dependency>
+
+
+        <!-- Testing -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.nimbusds</groupId>
+            <artifactId>nimbus-jose-jwt</artifactId>
+            <version>7.9</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.core</groupId>
+            <artifactId>jersey-client</artifactId>
+            <version>2.25.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcpkix-jdk15on</artifactId>
+            <version>1.53</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j18-impl</artifactId>
+            <version>${log.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <!-- Test rest client implementations-->
+        <dependency>
+            <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-rt-rs-mp-client</artifactId>
+            <version>${cxf.client.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.microprofile.rest.client</groupId>
+            <artifactId>microprofile-rest-client-api</artifactId>
+            <version>${mp.rest.client.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <!--Test database components-->
+        <dependency>
+            <groupId>com.opentable.components</groupId>
+            <artifactId>otj-pg-embedded</artifactId>
+            <version>${pg.embedded.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-core</artifactId>
+            <version>${flyway.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Coverage agent -->
+        <dependency>
+            <groupId>org.jacoco</groupId>
+            <artifactId>org.jacoco.agent</artifactId>
+            <version>${jacoco.plugin.version}</version>
+            <classifier>runtime</classifier>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+    <build>
+        <finalName>${project.artifactId}</finalName>
+    </build>
+
+</project>


### PR DESCRIPTION
Fixes issues where a project uses the [maven-flatten-plugin](https://www.mojohaus.org/flatten-maven-plugin/index.html), this plugin will now scan the created `.flattened-pom.xml` file. 

Note that depending on the `flattenMode` value used this may lose valuable information. This has primarily been tested with `resolveCiFriendliesOnly` which only flattens version number properties.