### PR TITLE
feat: add rule for NPM peer dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,12 @@ sonar.sources=src,package.json
 
 ### NPM Rules
 
-Two rules are made available in the `JavaScript` language by this plugin:
-* Allowed Development Dependencies (NPM) - `allowed-dependencies-npm:allowed-dependencies-dev`
+Three rules are made available in the `JavaScript` language by this plugin:
 * Allowed Dependencies (NPM) - `allowed-dependencies-npm:allowed-dependencies-main`
+* Allowed Development Dependencies (NPM) - `allowed-dependencies-npm:allowed-dependencies-dev`
+* Allowed Peer Dependencies (NPM) - `allowed-dependencies-npm:allowed-dependencies-peer`
 
-Both of these take a configuration element for a newline seperated list of dependencies which are allowed in a given scope (`devDependencies` and `dependencies` respectively). When a rule in enabled for a scope, a rule violation will be raised for any dependencies which are not in the allowed list.
+All of these take a configuration element for a newline seperated list of dependencies which are allowed in a given scope (`dependencies`, `devDependencies` and `peerDependencies` respectively). When a rule in enabled for a scope, a rule violation will be raised for any dependencies which are not in the allowed list.
 
 This plugin does not support:
 * version numbers

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
             <dependency>
                 <groupId>org.junit</groupId>
                 <artifactId>junit-bom</artifactId>
-                <version>5.7.1</version>
+                <version>5.8.2</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -102,7 +102,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>3.8.0</version>
+            <version>4.1.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/com/devwithimagination/sonar/alloweddependencies/plugin/npm/rules/NpmRulesDefinition.java
+++ b/src/main/java/com/devwithimagination/sonar/alloweddependencies/plugin/npm/rules/NpmRulesDefinition.java
@@ -27,9 +27,14 @@ public class NpmRulesDefinition implements RulesDefinition {
     public static final RuleKey RULE_NPM_ALLOWED = RuleKey.of(REPOSITORY_NPM, "allowed-dependencies-main");
 
     /**
-     * The rule key for the NPM allowed dependency check, for regular dependencies.
+     * The rule key for the NPM allowed dependency check, for development dependencies.
      */
     public static final RuleKey RULE_NPM_ALLOWED_DEV = RuleKey.of(REPOSITORY_NPM, "allowed-dependencies-dev");
+
+    /**
+     * The rule key for the NPM allowed dependency check, for perr dependencies.
+     */
+    public static final RuleKey RULE_NPM_ALLOWED_PEER = RuleKey.of(REPOSITORY_NPM, "allowed-dependencies-peer");
 
     /**
      * The setting key for the NPM allowed dependency list.
@@ -50,6 +55,10 @@ public class NpmRulesDefinition implements RulesDefinition {
         createRule(npmRepository, RULE_NPM_ALLOWED_DEV,
             "Allowed Development Dependencies (NPM)",
             "<p>This rule applies to dependencies in the <code>devDependencies</code> block.</p>");
+
+        createRule(npmRepository, RULE_NPM_ALLOWED_PEER,
+            "Allowed Peer Dependencies (NPM)",
+            "<p>This rule applies to dependencies in the <code>peerDependencies</code> block.</p>");
 
         // don't forget to call done() to finalize the definition
         npmRepository.done();
@@ -80,7 +89,7 @@ public class NpmRulesDefinition implements RulesDefinition {
             .setTags("npm", "dependency")
 
             // optional status. Default value is READY.
-            .setStatus(RuleStatus.BETA)
+            .setStatus(RuleStatus.READY)
 
             // default severity when the rule is activated on a Quality profile. Default
             // value is MAJOR.

--- a/src/test/java/com/devwithimagination/sonar/alloweddependencies/plugin/npm/check/TestAllowedNpmDependenciesCheck.java
+++ b/src/test/java/com/devwithimagination/sonar/alloweddependencies/plugin/npm/check/TestAllowedNpmDependenciesCheck.java
@@ -166,14 +166,19 @@ class TestAllowedNpmDependenciesCheck {
                     "primeng",
                     "rxjs",
                     "tslib",
-                    "uuid"))
+                    "uuid")),
+            Arguments.of(
+                NpmRulesDefinition.RULE_NPM_ALLOWED_PEER,
+                String.join("\n",
+                    "tea",
+                    "coffee"))
         );
 
     }
 
     /**
      * Method to create the parameters for {@link #checkForViolations()}.
-     * @return Stream containing the argument pairs.
+     * @return Stream containing the arguments.
      */
     private static Stream<Arguments> provideViolationParameters() {
 
@@ -200,7 +205,16 @@ class TestAllowedNpmDependenciesCheck {
                     "primeicons",
                     "tslib",
                     "uuid"),
-                2)
+                2),
+            Arguments.of(
+                NpmRulesDefinition.RULE_NPM_ALLOWED_PEER,
+                "",
+                2),
+            Arguments.of(
+                NpmRulesDefinition.RULE_NPM_ALLOWED_PEER,
+                "tea",
+                1)
+
         );
 
     }

--- a/src/test/java/com/devwithimagination/sonar/alloweddependencies/plugin/npm/rules/TestNpmRulesDefinition.java
+++ b/src/test/java/com/devwithimagination/sonar/alloweddependencies/plugin/npm/rules/TestNpmRulesDefinition.java
@@ -3,6 +3,9 @@ package com.devwithimagination.sonar.alloweddependencies.plugin.npm.rules;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 import org.junit.jupiter.api.Test;
 import org.sonar.api.server.rule.RulesDefinition.Context;
 import org.sonar.api.server.rule.RulesDefinition.Repository;
@@ -38,8 +41,16 @@ class TestNpmRulesDefinition {
 
         assertEquals(NpmRulesDefinition.REPOSITORY_NPM, repository.key());
         assertEquals(NpmRulesDefinition.NPM_DEPENDENCY_LANGUAGE, repository.language());
-        assertEquals(2, repository.rules().size(), "Expected two rules, one for each type of dependency");
-        // TODO: Implement
+        assertEquals(3, repository.rules().size(), "Expected three rules, one for each type of dependency");
+
+        final List<String> ruleKeys = repository.rules()
+            .stream()
+            .map(r -> r.key())
+            .sorted()
+            .collect(Collectors.toList());
+        assertEquals(NpmRulesDefinition.RULE_NPM_ALLOWED_DEV.rule(), ruleKeys.get(0));
+        assertEquals(NpmRulesDefinition.RULE_NPM_ALLOWED.rule(), ruleKeys.get(1));
+        assertEquals(NpmRulesDefinition.RULE_NPM_ALLOWED_PEER.rule(), ruleKeys.get(2));
 
     }
 

--- a/src/test/resources/npm/package.json
+++ b/src/test/resources/npm/package.json
@@ -16,5 +16,9 @@
     "@angular/compiler-cli": "^11.0.5",
     "@angular/language-service": "^11.0.5",
     "@cypress/code-coverage": "^3.8.8"
+  },
+  "peerDependencies": {
+    "tea": "2.x",
+    "coffee": "3.x"
   }
 }


### PR DESCRIPTION
Adds a new rule for what is allowed in a `peerDependencies` block. 

Fixes #14