### PR TITLE
fix: standardised issue messages #17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,17 @@
         </license>
     </licenses>
 
+    <issueManagement>
+		<url>https://github.com/dhutchison/sonar-alloweddependencies-plugin/issues</url>
+		<system>GitHub Issues</system>
+	</issueManagement>
+
+    <scm>
+		<url>https://github.com/dhutchison/sonar-alloweddependencies-plugin</url>
+		<connection>scm:git:https://github.com/dhutchison/sonar-alloweddependencies-plugin.git</connection>
+		<developerConnection>scm:git:https://github.com/dhutchison/sonar-alloweddependencies-plugin.git</developerConnection>
+	</scm>
+
     <!-- this is important for sonar-packaging-maven-plugin -->
     <packaging>sonar-plugin</packaging>
 
@@ -30,11 +41,6 @@
             <url>https://maven.pkg.github.com/dhutchison/sonar-alloweddependencies-plugin</url>
         </snapshotRepository>
     </distributionManagement>
-
-    <scm>
-        <developerConnection>scm:git:https://github.com/dhutchison/sonar-alloweddependencies-plugin.git</developerConnection>
-      <tag>v0.1.7</tag>
-  </scm>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/com/devwithimagination/sonar/alloweddependencies/plugin/common/Constants.java
+++ b/src/main/java/com/devwithimagination/sonar/alloweddependencies/plugin/common/Constants.java
@@ -1,0 +1,18 @@
+package com.devwithimagination.sonar.alloweddependencies.plugin.common;
+
+/**
+ * Class containing common constants which apply to all implementations.
+ */
+public final class Constants {
+
+    private Constants() {
+
+    }
+
+    /**
+     * The message to use for created issues. This contains a string placeholder for
+     * inserting the name of the dependency which was not on the allowed list.
+     */
+    public static final String ISSUE_MESSAGE = "Remove this forbidden dependency: %s.";
+
+}

--- a/src/main/java/com/devwithimagination/sonar/alloweddependencies/plugin/maven/checks/AllowedMavenDependenciesCheck.java
+++ b/src/main/java/com/devwithimagination/sonar/alloweddependencies/plugin/maven/checks/AllowedMavenDependenciesCheck.java
@@ -1,5 +1,7 @@
 package com.devwithimagination.sonar.alloweddependencies.plugin.maven.checks;
 
+import static com.devwithimagination.sonar.alloweddependencies.plugin.common.Constants.ISSUE_MESSAGE;
+
 import java.util.Arrays;
 import java.util.List;
 
@@ -81,7 +83,7 @@ public class AllowedMavenDependenciesCheck extends SimpleXPathBasedCheck {
 
                     LOG.info("Forbidden dependency: {}", listKey);
 
-                    reportIssue(dependency, "Remove this forbidden dependency.");
+                    reportIssue(dependency, String.format(ISSUE_MESSAGE, listKey));
                 }
             });
         }

--- a/src/main/java/com/devwithimagination/sonar/alloweddependencies/plugin/npm/checks/AllowedNpmDependenciesCheck.java
+++ b/src/main/java/com/devwithimagination/sonar/alloweddependencies/plugin/npm/checks/AllowedNpmDependenciesCheck.java
@@ -1,5 +1,7 @@
 package com.devwithimagination.sonar.alloweddependencies.plugin.npm.checks;
 
+import static com.devwithimagination.sonar.alloweddependencies.plugin.common.Constants.ISSUE_MESSAGE;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.HashSet;
@@ -117,7 +119,7 @@ public class AllowedNpmDependenciesCheck {
             .at(
                 new DefaultIssueLocation()
                     .on(inputFile)
-                    .message("Dependency " + dependency + " is not on the allowed list"));
+                    .message(String.format(ISSUE_MESSAGE, dependency)));
 
         issue.save();
     }


### PR DESCRIPTION
Standardises the created issue messages between the NPM & Maven implementations so they include the name of the dependency to be removed. 

Closes #17